### PR TITLE
refactor: read valetTls from env variable

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import tailwindcss from 'tailwindcss'
 import autoprefixer from 'autoprefixer'
 import laravel from 'laravel-vite-plugin'
@@ -14,62 +14,66 @@ import components from 'unplugin-vue-components/vite'
 import icons from 'unplugin-icons/vite'
 import run from 'vite-plugin-run'
 
-export default defineConfig({
-	plugins: [
-		laravel({
-			input: 'resources/application/main.ts',
-			valetTls: true,
-		}),
-		run({
-			name: 'generate typescript',
-			run: ['php', 'artisan', 'typescript:transform'],
-			condition: (file) => ['Data.php', 'Enums'].some((kw) => file.includes(kw)),
-		}),
-		hybridly(),
-		vue(),
-		icons({
-			autoInstall: true,
-			customCollections: {
-				bluebird: FileSystemIconLoader('./resources/icons'),
+export default ({ mode }) => {
+	process.env = Object.assign(process.env, loadEnv(mode, process.cwd(), ''))
+
+	return defineConfig({
+		plugins: [
+			laravel({
+				input: 'resources/application/main.ts',
+				valetTls: process.env.VITE_VALET_TLS,
+			}),
+			run({
+				name: 'generate typescript',
+				run: ['php', 'artisan', 'typescript:transform'],
+				condition: (file) => ['Data.php', 'Enums'].some((kw) => file.includes(kw)),
+			}),
+			hybridly(),
+			vue(),
+			icons({
+				autoInstall: true,
+				customCollections: {
+					bluebird: FileSystemIconLoader('./resources/icons'),
+				},
+			}),
+			autoimport({
+				dts: 'resources/types/auto-imports.d.ts',
+				imports: [
+					'vue',
+					'@vueuse/core',
+					'@vueuse/head',
+					hybridlyImports,
+				],
+				vueTemplate: true,
+			}),
+			components({
+				dirs: [
+					'./resources/views/components',
+				],
+				resolvers: [
+					hybridlyResolver({
+						linkName: 'RouterLink',
+					}),
+					iconsResolver({
+						customCollections: ['bluebird'],
+					}),
+				],
+				directoryAsNamespace: true,
+				dts: 'resources/types/components.d.ts',
+			}),
+		],
+		resolve: {
+			alias: {
+				'@': path.join(process.cwd(), 'resources'),
 			},
-		}),
-		autoimport({
-			dts: 'resources/types/auto-imports.d.ts',
-			imports: [
-				'vue',
-				'@vueuse/core',
-				'@vueuse/head',
-				hybridlyImports,
-			],
-			vueTemplate: true,
-		}),
-		components({
-			dirs: [
-				'./resources/views/components',
-			],
-			resolvers: [
-				hybridlyResolver({
-					linkName: 'RouterLink',
-				}),
-				iconsResolver({
-					customCollections: ['bluebird'],
-				}),
-			],
-			directoryAsNamespace: true,
-			dts: 'resources/types/components.d.ts',
-		}),
-	],
-	resolve: {
-		alias: {
-			'@': path.join(process.cwd(), 'resources'),
 		},
-	},
-	css: {
-		postcss: {
-			plugins: [
-				tailwindcss(),
-				autoprefixer(),
-			],
+		css: {
+			postcss: {
+				plugins: [
+					tailwindcss(),
+					autoprefixer(),
+				],
+			},
 		},
-	},
-})
+	})
+}


### PR DESCRIPTION
Currently the Vite config makes an assumption that valet is available on the system. This causes below error when that's not the case:
`Unable to find Valet certificate files for your host`

The PR is to make `valetTls` an opt-in.