### PR TITLE
chore: un-ignore non-root `public` and `vendor` directories

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,6 @@
-./node_modules
-./public
-./vendor
+node_modules
+public
+vendor
 **/dist
+!**/public
+!**/vendor

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,4 @@
 node_modules
-public
-vendor
+./vendor
+./public
 **/dist
-!**/public
-!**/vendor

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-node_modules
-public
-vendor
+./node_modules
+./public
+./vendor
 **/dist


### PR DESCRIPTION
While working in a project with same `.eslintignore` config used in this repo, I noticed ESLint will totally ignore the files put in any directory named `public`. Like :
```
./resources/views/pages/public/products/category.vue
```

I think it's better to just ignore the mentioned directories at root level. This way people who follow the demo app convention will not run into the same issues if they happen to use directory names such as `public`.