### PR TITLE
fix: invalid locales path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 			customIcons: ['bluebird'],
 		}),
 		i18n({
-			include: path.resolve(__dirname, './hybridly/locales.json'),
+			include: path.resolve(__dirname, './.hybridly/locales.json'),
 		}),
 	],
 	resolve: {


### PR DESCRIPTION
The path current points to the `hybridly` folder but I believe you meant `.hybridly`.