### PR TITLE
fix: properly paginate chirps

### DIFF
--- a/resources/utils/chirps.ts
+++ b/resources/utils/chirps.ts
@@ -3,7 +3,7 @@ import { useAutoAnimate } from '@formkit/auto-animate/vue'
 export function useInfiniteChirpLoading(initialChirps: Paginator<App.Data.ChirpData>) {
 	const [list, enableChirpAnimations] = useAutoAnimate()
 	const meta = ref(initialChirps.meta)
-	const chirps = ref([...initialChirps.data])
+	const chirps = ref(initialChirps.data)
 	const canLoad = computed(() => !!meta.value.next_page_url)
 
 	function loadMoreChirps() {

--- a/resources/utils/chirps.ts
+++ b/resources/utils/chirps.ts
@@ -2,9 +2,9 @@ import { useAutoAnimate } from '@formkit/auto-animate/vue'
 
 export function useInfiniteChirpLoading(initialChirps: Paginator<App.Data.ChirpData>) {
 	const [list, enableChirpAnimations] = useAutoAnimate()
-	const canLoad = computed(() => !!initialChirps.meta.next_page_url)
 	const meta = ref(initialChirps.meta)
 	const chirps = ref([...initialChirps.data])
+	const canLoad = computed(() => !!meta.value.next_page_url)
 
 	function loadMoreChirps() {
 		if (!canLoad.value) {

--- a/resources/utils/chirps.ts
+++ b/resources/utils/chirps.ts
@@ -2,22 +2,27 @@ import { useAutoAnimate } from '@formkit/auto-animate/vue'
 
 export function useInfiniteChirpLoading(initialChirps: Paginator<App.Data.ChirpData>) {
 	const [list, enableChirpAnimations] = useAutoAnimate()
-	const canLoad = computed(() => !!initialChirps.meta?.next_page_url)
-	const chirps = ref<App.Data.ChirpData[]>([...initialChirps.data])
+	const canLoad = computed(() => !!initialChirps.meta.next_page_url)
+	const meta = ref(initialChirps.meta)
+	const chirps = ref([...initialChirps.data])
 
 	function loadMoreChirps() {
 		if (!canLoad.value) {
 			return
 		}
 
-		router.get(initialChirps.meta!.next_page_url!, {
+		router.get(meta.value.next_page_url!, {
 			preserveState: true,
 			preserveScroll: true,
 			preserveUrl: true,
 			only: ['chirps'],
 			hooks: {
 				before: () => enableChirpAnimations(false),
-				success: () => chirps.value.push(...initialChirps.data),
+				success: ({ view }) => {
+					const paginatedChirps = view.properties.chirps as unknown as Paginator<App.Data.ChirpData>
+					chirps.value.push(...paginatedChirps.data)
+					meta.value = paginatedChirps.meta
+				},
 				after: () => enableChirpAnimations(true),
 			},
 		})


### PR DESCRIPTION
This PR should properly call the next page and update the existing chirps list with the newly loaded one